### PR TITLE
Fixes reference to DeviceClass Power for compatibility for home assistant 2025.1

### DIFF
--- a/custom_components/maxsmart/sensor.py
+++ b/custom_components/maxsmart/sensor.py
@@ -1,7 +1,7 @@
 """Platform for sensor integration."""
 import logging
 from datetime import timedelta
-from homeassistant.const import DEVICE_CLASS_POWER
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
 from .const import DOMAIN
@@ -115,4 +115,4 @@ class HaMaxSmartPowerSensor(Entity):
 
     @property
     def device_class(self):
-        return DEVICE_CLASS_POWER
+        return SensorDeviceClass.POWER


### PR DESCRIPTION
Due to changes in home assistant constants in 2025.1, the reference to homeassistant.const.DEVICE_CLASS_POWER is broken. homeassistant.components.sensor.SensorDeviceClass.POWER to be used instead as implemented in this PR.